### PR TITLE
fix: CKV_AWS_8 & CKV_AWS_88 checkov alerts.

### DIFF
--- a/.checkov.yml
+++ b/.checkov.yml
@@ -1,9 +1,0 @@
-directory:
-- .
-download-external-modules: false
-evaluate-variables: true
-external-modules-download-path: .external_modules
-framework: all
-skip-check:
-- CKV_AWS_88 #EC2 instance should not have public IP.
-- CKV_AWS_8 #Ensure all data stored in the Launch configuration or instance Elastic Blocks Store is securely encrypted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- fix: CKV_AWS_88: EC2 instance should not have public IP.
+
 - fix: CKV_AWS_79  Ensure Instance Metadata Service Version 1 is not enabled:: V1 is used for the examples
-- fix: CKV_AWS_8 #Ensure all data stored in the Launch configuration or instance Elastic Blocks Store is securely encrypted
 - Feature: Add Operating System flexibility in script (i.e download/install packages depending on OS flavor)
 - Feat: pair different subnet IDs with their corresponding CIDRs for consistency in examples usage
 - Feat: use vpc version to 3.0.2 in supporting resources
+
+##  [1.2.1] - 2023-02-03
+### Changes
+- fix: CKV_AWS_88: EC2 instance should not have public IP.
+- fix: CKV_AWS_8 :Ensure all data stored in the Launch configuration or instance Elastic Blocks Store is securely encrypted
 
 ## [1.2.0] - 2023-01-10
 ### Changes
@@ -81,7 +85,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0] - 2022-02-17
 - Initial commit
 
-[Unreleased]: https://github.com/boldlink/terraform-aws-ec2/compare/1.2.0...HEAD
+[Unreleased]: https://github.com/boldlink/terraform-aws-ec2/compare/1.2.1...HEAD
+[1.2.1]: https://github.com/boldlink/terraform-aws-ec2/releases/tag/1.2.1
 [1.2.0]: https://github.com/boldlink/terraform-aws-ec2/releases/tag/1.2.0
 [1.1.9]: https://github.com/boldlink/terraform-aws-ec2/releases/tag/1.1.9
 [1.1.8]: https://github.com/boldlink/terraform-aws-ec2/releases/tag/1.1.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Feature: Add Operating System flexibility in script (i.e download/install packages depending on OS flavor)
 - Feat: pair different subnet IDs with their corresponding CIDRs for consistency in examples usage
 - Feat: use vpc version to 3.0.2 in supporting resources
+- fix: Ensure packages are installed without public IP
 
 ##  [1.2.1] - 2023-02-03
 ### Changes

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ module "ec2_instance_minimum" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
 | <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.4 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 3.4.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -184,11 +184,35 @@ This repository uses third party software:
   * Install with `brew install tflint`
   * Manually use via pre-commit
 
+### Supporting resources:
+
+The example stacks are used by BOLDLink developers to validate the modules by building an actual stack on AWS.
+
+Some of the modules have dependencies on other modules (ex. Ec2 instance depends on the VPC module) so we create them
+first and use data sources on the examples to use the stacks.
+
+Any supporting resources will be available on the `tests/supportingResources` and the lifecycle is managed by the `Makefile` targets.
+
+Resources on the `tests/supportingResources` folder are not intended for demo or actual implementation purposes, and can be used for reference.
+
 ### Makefile
 The makefile contained in this repo is optimized for linux paths and the main purpose is to execute testing for now.
-* Create all tests:
-`$ make tests`
-* Clean all tests:
-`$ make clean`
+* Create all tests stacks including any supporting resources:
+```console
+make tests
+```
+* Clean all tests *except* existing supporting resources:
+```console
+make clean
+```
+* Clean supporting resources - this is done separately so you can test your module build/modify/destroy independently.
+```console
+make cleansupporting
+```
+* !!!DANGER!!! Clean the state files from examples and test/supportingResources - use with CAUTION!!!
+```console
+make cleanstatefiles
+```
+
 
 #### BOLDLink-SIG 2023

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ module "ec2_instance_minimum" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.52.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.53.0 |
 | <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.4 |
 

--- a/README.md
+++ b/README.md
@@ -191,4 +191,4 @@ The makefile contained in this repo is optimized for linux paths and the main pu
 * Clean all tests:
 `$ make clean`
 
-#### BOLDLink-SIG 2022
+#### BOLDLink-SIG 2023

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ module "ec2_instance_minimum" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.17.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.52.0 |
 | <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 3.4.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.4 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -63,4 +63,4 @@ This repository uses third party software:
   * Install with `brew install tflint`
   * Manually use via pre-commit
 
-#### BOLDLink-SIG 2022
+#### BOLDLink-SIG 2023

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,7 +24,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.49.0 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,7 +24,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.52.0 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,7 +24,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.52.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.53.0 |
 
 ## Modules
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -11,7 +11,6 @@ module "ec2_instance_complete" {
   subnet_id                   = local.public_subnets
   create_ec2_kms_key          = true
   create_key_pair             = true
-  associate_public_ip_address = true
   ebs_optimized               = true
   create_instance_iam_role    = true
   disable_api_termination     = false

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -2,24 +2,24 @@
 ### This example shows the complete values to use this module
 ##############################################################
 module "ec2_instance_complete" {
-  source                      = "../../"
-  name                        = local.name
-  ami                         = data.aws_ami.amazon_linux.id
-  instance_type               = "t3.medium"
-  vpc_id                      = local.vpc_id
-  availability_zone           = local.azs
-  subnet_id                   = local.public_subnets
-  create_ec2_kms_key          = true
-  create_key_pair             = true
-  ebs_optimized               = true
-  create_instance_iam_role    = true
-  disable_api_termination     = false
-  monitoring                  = true
-  source_dest_check           = false
-  enclave_options_enabled     = false
-  private_ip                  = local.private_ip
-  secondary_private_ips       = local.secondary_ips
-  tenancy                     = "default"
+  source                   = "../../"
+  name                     = local.name
+  ami                      = data.aws_ami.amazon_linux.id
+  instance_type            = "t3.medium"
+  vpc_id                   = local.vpc_id
+  availability_zone        = local.azs
+  subnet_id                = local.public_subnets
+  create_ec2_kms_key       = true
+  create_key_pair          = true
+  ebs_optimized            = true
+  create_instance_iam_role = true
+  disable_api_termination  = false
+  monitoring               = true
+  source_dest_check        = false
+  enclave_options_enabled  = false
+  private_ip               = local.private_ip
+  secondary_private_ips    = local.secondary_ips
+  tenancy                  = "default"
 
   instance_initiated_shutdown_behavior = "terminate"
 

--- a/examples/cpu_credits/README.md
+++ b/examples/cpu_credits/README.md
@@ -63,4 +63,4 @@ This repository uses third party software:
   * Install with `brew install tflint`
   * Manually use via pre-commit
 
-#### BOLDLink-SIG 2022
+#### BOLDLink-SIG 2023

--- a/examples/cpu_credits/README.md
+++ b/examples/cpu_credits/README.md
@@ -24,7 +24,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.49.0 |
 
 ## Modules
 

--- a/examples/cpu_credits/README.md
+++ b/examples/cpu_credits/README.md
@@ -24,7 +24,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.52.0 |
 
 ## Modules
 

--- a/examples/cpu_credits/README.md
+++ b/examples/cpu_credits/README.md
@@ -24,7 +24,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.52.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.53.0 |
 
 ## Modules
 

--- a/examples/cpu_credits/main.tf
+++ b/examples/cpu_credits/main.tf
@@ -11,7 +11,6 @@ module "ec2_instance_t3" {
   subnet_id                            = local.public_subnets
   ebs_optimized                        = true
   create_ec2_kms_key                   = true
-  associate_public_ip_address          = true
   monitoring                           = true
   source_dest_check                    = false
   enclave_options_enabled              = false
@@ -25,5 +24,15 @@ module "ec2_instance_t3" {
     http_tokens                 = "required"
     http_put_response_hop_limit = 15
   }
+
+  root_block_device = [
+    {
+      volume_size           = 15
+      volume_type           = "gp3"
+      delete_on_termination = true
+      encrypted             = true
+      iops                  = 300
+    }
+  ]
   tags = local.tags
 }

--- a/examples/minimum/README.md
+++ b/examples/minimum/README.md
@@ -63,4 +63,4 @@ This repository uses third party software:
   * Install with `brew install tflint`
   * Manually use via pre-commit
 
-#### BOLDLink-SIG 2022
+#### BOLDLink-SIG 2023

--- a/examples/minimum/README.md
+++ b/examples/minimum/README.md
@@ -24,7 +24,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.49.0 |
 
 ## Modules
 

--- a/examples/minimum/README.md
+++ b/examples/minimum/README.md
@@ -24,7 +24,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.52.0 |
 
 ## Modules
 

--- a/examples/minimum/README.md
+++ b/examples/minimum/README.md
@@ -24,7 +24,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.52.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.53.0 |
 
 ## Modules
 

--- a/examples/minimum/main.tf
+++ b/examples/minimum/main.tf
@@ -14,8 +14,8 @@ module "ec2_instance_minimum" {
   tags              = local.tags
   root_block_device = [
     {
-      volume_size           = 15
-      encrypted             = true
+      volume_size = 15
+      encrypted   = true
     }
-  ]  
+  ]
 }

--- a/examples/minimum/main.tf
+++ b/examples/minimum/main.tf
@@ -2,7 +2,7 @@
 # This example shows the minimum values to use this module
 ##############################################################
 module "ec2_instance_minimum" {
-  source = "../../"
+  source            = "../../"
   name              = local.name
   ami               = data.aws_ami.amazon_linux.id
   instance_type     = "t3.small"

--- a/examples/minimum/main.tf
+++ b/examples/minimum/main.tf
@@ -12,4 +12,10 @@ module "ec2_instance_minimum" {
   availability_zone = local.azs
   subnet_id         = local.public_subnets
   tags              = local.tags
+  root_block_device = [
+    {
+      volume_size           = 15
+      encrypted             = true
+    }
+  ]  
 }

--- a/examples/minimum/main.tf
+++ b/examples/minimum/main.tf
@@ -3,7 +3,6 @@
 ##############################################################
 module "ec2_instance_minimum" {
   source = "../../"
-  #checkov:skip=CKV_AWS_126:Ensure that detailed monitoring is enabled for EC2 instances
   name              = local.name
   ami               = data.aws_ami.amazon_linux.id
   instance_type     = "t3.small"

--- a/examples/windows-instance/README.md
+++ b/examples/windows-instance/README.md
@@ -63,4 +63,4 @@ This repository uses third party software:
   * Install with `brew install tflint`
   * Manually use via pre-commit
 
-#### BOLDLink-SIG 2022
+#### BOLDLink-SIG 2023

--- a/examples/windows-instance/README.md
+++ b/examples/windows-instance/README.md
@@ -24,7 +24,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.49.0 |
 
 ## Modules
 

--- a/examples/windows-instance/README.md
+++ b/examples/windows-instance/README.md
@@ -24,7 +24,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.52.0 |
 
 ## Modules
 

--- a/examples/windows-instance/README.md
+++ b/examples/windows-instance/README.md
@@ -24,7 +24,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.52.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.53.0 |
 
 ## Modules
 

--- a/examples/windows-instance/main.tf
+++ b/examples/windows-instance/main.tf
@@ -1,10 +1,8 @@
 module "ec2_instance_windows" {
   source = "../../"
-  #checkov:skip=CKV_AWS_126:Ensure that detailed monitoring is enabled for EC2 instances
   name                                 = local.name
   ami                                  = data.aws_ami.windows.id
   instance_type                        = "t3.medium"
-  associate_public_ip_address          = true
   create_ec2_kms_key                   = true
   ebs_optimized                        = true
   vpc_id                               = local.vpc_id
@@ -14,6 +12,7 @@ module "ec2_instance_windows" {
   get_password_data                    = true
   tenancy                              = "default"
   instance_initiated_shutdown_behavior = "terminate"
+  monitoring                           = true
 
   metadata_options = {
     http_endpoint               = "enabled"

--- a/examples/windows-instance/main.tf
+++ b/examples/windows-instance/main.tf
@@ -1,5 +1,5 @@
 module "ec2_instance_windows" {
-  source = "../../"
+  source                               = "../../"
   name                                 = local.name
   ami                                  = data.aws_ami.windows.id
   instance_type                        = "t3.medium"

--- a/tests/supportingResources/README.md
+++ b/tests/supportingResources/README.md
@@ -29,7 +29,7 @@ This stack builds:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.52.0 |
 
 ## Modules
 

--- a/tests/supportingResources/README.md
+++ b/tests/supportingResources/README.md
@@ -67,14 +67,29 @@ This repository uses third party software:
   * Install with `brew install tflint`
   * Manually use via pre-commit
 
+## Third party software
+This repository uses third party software:
+* [pre-commit](https://pre-commit.com/) - Used to help ensure code and documentation consistency
+  * Install with `brew install pre-commit`
+  * Manually use with `pre-commit run`
+* [terraform 0.14.11](https://releases.hashicorp.com/terraform/0.14.11/) For backwards compatibility we are using version 0.14.11 for testing making this the min version tested and without issues with terraform-docs.
+* [terraform-docs](https://github.com/segmentio/terraform-docs) - Used to generate the [Inputs](#Inputs) and [Outputs](#Outputs) sections
+  * Install with `brew install terraform-docs`
+  * Manually use via pre-commit
+* [tflint](https://github.com/terraform-linters/tflint) - Used to lint the Terraform code
+  * Install with `brew install tflint`
+  * Manually use via pre-commit
+
 ### Supporting resources:
 
 The example stacks are used by BOLDLink developers to validate the modules by building an actual stack on AWS.
 
-Some of the modules have dependencies on other modules (ex. Ec2 instance depends on the VPC) so we create them
+Some of the modules have dependencies on other modules (ex. Ec2 instance depends on the VPC module) so we create them
 first and use data sources on the examples to use the stacks.
 
 Any supporting resources will be available on the `tests/supportingResources` and the lifecycle is managed by the `Makefile` targets.
+
+Resources on the `tests/supportingResources` folder are not intended for demo or actual implementation purposes, and can be used for reference.
 
 ### Makefile
 The makefile contained in this repo is optimized for linux paths and the main purpose is to execute testing for now.
@@ -86,9 +101,14 @@ make tests
 ```console
 make clean
 ```
-* Clean supporting resources - this is done seperately so you can test your module build/modify/destroy independently.
+* Clean supporting resources - this is done separately so you can test your module build/modify/destroy independently.
 ```console
 make cleansupporting
 ```
+* !!!DANGER!!! Clean the state files from examples and test/supportingResources - use with CAUTION!!!
+```console
+make cleanstatefiles
+```
+
 
 #### BOLDLink-SIG 2023

--- a/tests/supportingResources/README.md
+++ b/tests/supportingResources/README.md
@@ -29,7 +29,7 @@ This stack builds:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.49.0 |
 
 ## Modules
 

--- a/tests/supportingResources/README.md
+++ b/tests/supportingResources/README.md
@@ -91,4 +91,4 @@ make clean
 make cleansupporting
 ```
 
-#### BOLDLink-SIG 2022
+#### BOLDLink-SIG 2023

--- a/tests/supportingResources/README.md
+++ b/tests/supportingResources/README.md
@@ -29,7 +29,7 @@ This stack builds:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.52.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.53.0 |
 
 ## Modules
 


### PR DESCRIPTION
# Description

This PR fixes the following checkov alerts:
CKV_AWS_8: EC2 instance should not have public IP.
CKV_AWS_88: Ensure all data stored in the Launch configuration or instance Elastic Blocks Store is securely encrypted

## Features/Fixes/Patches/Changes list:

Please check the [CHANGELOG.md](https://github.com/boldlink/terraform-aws-ec2/blob/fix/CKV_AWS_8/CHANGELOG.md#121---2023-02-03)

## Checklists:
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
### PR Owners Checklist:
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you checked there aren't open [Pull Requests](../../../pulls) of upstream or parallel code that will cause conflicts?
* [x] Have you updated the `CHANGELOG.md`?
* [x] Have you updated the `README.md`(s)?
* [x] OWNER: Does your submission pass?
    * [ ] Pre-commit (attach logs/print screen to this PR)
    * [ ] Checkov/terrascan (attach logs/print screen to this PR)
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### PR Reviewers Checklists?
* [ ] Are all your comments/changes resolved?
* [ ] Are you happy with the OWNER checklists and additional information provided?
* [ ] Does your review tests pass?
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
